### PR TITLE
fix(styles.css) fix top navigation

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -15,7 +15,6 @@ html,body{
 }
 
 .container{
-    min-height: 45vh;
     max-width: 900px;
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
- Remove `min-height: 45vh;` from `.container` because
  it was breaking usability of the website's top navigation.

Top navigation links were not functional,
because transparent div container was blocking
the mouse clicks to elements in the header.

Below you can see two screen captures of the invisible element that was causing the issue.

### Before the change:

![screen shot 2017-08-25 at 03 08 54-fullpage](https://user-images.githubusercontent.com/135053/29694309-e7550e68-8943-11e7-95dd-373323051cee.png)

### After the change:

![screen shot 2017-08-25 at 03 16 57-fullpage](https://user-images.githubusercontent.com/135053/29694316-f82c7870-8943-11e7-8d5d-1cf2b13c3a9e.png)
